### PR TITLE
Fix Manifest after issue_template change

### DIFF
--- a/PlasterManifest.xml
+++ b/PlasterManifest.xml
@@ -51,7 +51,8 @@
             <file source='' destination='classes' condition='$PLASTER_PARAM_ModuleFolders -contains "classes"'/>
         <message condition='$PLASTER_PARAM_GitHub -like "Yes"'>Creating GitHub folder and files</message>
             <file source='' destination='.github' condition='$PLASTER_PARAM_GitHub -eq "Yes"'/>
-            <file source='.github\ISSUE_TEMPLATE.md' destination='' condition='$PLASTER_PARAM_GitHub -eq "Yes"'/>
+            <file source='.github\ISSUE_TEMPLATE\Bug_report.md' destination='' condition='$PLASTER_PARAM_GitHub -eq "Yes"'/>
+            <file source='.github\ISSUE_TEMPLATE\Feature_request.md' destination='' condition='$PLASTER_PARAM_GitHub -eq "Yes"'/>
             <file source='.github\PULL_REQUEST_TEMPLATE.md' destination='' condition='$PLASTER_PARAM_GitHub -eq "Yes"'/>
             <templateFile source='code-of-conduct.md' destination='' condition='$PLASTER_PARAM_GitHub -eq "Yes"'/>
             <templateFile source='contributing.md' destination='' condition='$PLASTER_PARAM_GitHub -eq "Yes"'/>


### PR DESCRIPTION
### Requirements

* This template is required. Any request that does not include enough information may be closed at the maintainers' discretion.
* Have you (put an X between the brackets on each line to confirm):
    * [ ] Written new test cases to ensure no regression bugs occur?
    * [ ] Ensured all test cases are now passing?
    * [ ] Ensured that PowerShell Script Analyser issues and warnings are completely resolved?
    * [ X] Updated any help or documentation that may be impacted by your changes?

### Description of the Change

Added new entries to create Bug_report.md and Feature_request.md after changes to Github Issue_template was made. The changes on the last Commit changed the folder structure from .github\ISSUE_TEMPLATE to .github\ISSUE_TEMPLATE\Bug_report.md and .github\ISSUE_TEMPLATE\Feature_request.md  but did not update the links in the plaster manifest to mirror that change. I only updated the manifest to properly refer to the correct files.

### Testing

 I am still pretty new to PS and am just getting into Pester testing, but since I was not able to use this template without an error thrown about files not existing (due to manifest being incorrect) I would guess that new tests need to be written if they were previously passing. I am not qualified at this time to update the tests.


### Associated/Resolved Issues

Resolved error when using the template that caused an error to be thrown about file not existing.

> Note: By creating a pull request, you are expected to comply with this project's Code of Conduct.

<!--

    This template is based upon the work by the Atom project, https://github.com/atom/atom/

-->